### PR TITLE
Update Install Script to fix error during Swift UI monitoring setup

### DIFF
--- a/scripts/installDependencies.js
+++ b/scripts/installDependencies.js
@@ -197,9 +197,11 @@ if (platform == "macos") {
 
 	console.log("Setting up Swift UI monitoring...");
 	try {
-		const swiftSrc = mkdirSync(
-			path.join(binDir, "..", "temp", "ui_monitoring_macos.swift")
-		);
+		const tempDir = path.join(binDir, "..", "temp");
+		if (!existsSync(tempDir)) {
+			mkdirSync(tempDir, { recursive: true });
+		}
+		const swiftSrc = path.join(tempDir, "ui_monitoring_macos.swift");
 		await download(
 			`https://raw.githubusercontent.com/mediar-ai/screenpipe/refs/tags/v${process.env.SCREENPIPE_VERSION}/screenpipe-vision/src/ui_monitoring_macos.swift`,
 			swiftSrc


### PR DESCRIPTION
The `installDependencies.js` script fails during Swift UI monitoring setup.

happens because:
1. `mkdirSync()` was being called with a file path (including `.swift` filename) instead of a directory path
2. `mkdirSync()` returns `undefined`, which was then passed to the `download()` function causing a "path must be string" error
3. The parent `temp/` directory didn't exist

### Solution
- Create the `temp` directory properly using `mkdirSync(tempDir, { recursive: true })`
- Construct the Swift file path separately using `path.join()`
- Check if directory exists before creating it to avoid conflicts